### PR TITLE
fix: --files-only --configure now substitutes placeholders (closes #75)

### DIFF
--- a/src/ghtraf/commands/create.py
+++ b/src/ghtraf/commands/create.py
@@ -385,7 +385,26 @@ def _run_files_only(args):
         print_info("")
         print_info(f"  Copied {copied} file(s), skipped {skipped} file(s).")
 
-    if not dry_run and any(
+    # Run configure if requested (fixes #75)
+    if not dry_run and getattr(args, 'configure_files', False):
+        import json as _json
+        config_path = Path(repo_dir) / ".ghtraf.json"
+        if config_path.exists():
+            config = _json.loads(config_path.read_text(encoding="utf-8"))
+            dashboard_path = Path(repo_dir) / "docs" / "stats" / "index.html"
+            readme_path = Path(repo_dir) / "docs" / "stats" / "README.md"
+            workflow_path = Path(repo_dir) / ".github" / "workflows" / "traffic-badges.yml"
+
+            print_info("\nConfiguring project files...")
+            configure.configure_dashboard(config, dashboard_path)
+            configure.configure_readme(config, readme_path)
+            configure.configure_workflow(config, workflow_path)
+            print_info("")
+        else:
+            print_warn(f"No .ghtraf.json found at {config_path}")
+            print_info("  Run 'ghtraf create --configure' (without --files-only) to configure.")
+
+    elif not dry_run and any(
         r.success and not r.skipped for r in results
     ):
         import ghtraf.hints  # noqa: F401


### PR DESCRIPTION
Refs #75 (partial — see issue for remaining scope)

## Problem

When running `ghtraf create --files-only --configure`, the `--configure` flag was ignored. The `_run_files_only` function dispatched immediately without checking for it, so placeholders like `PLACEHOLDER`, `OWNER/REPO`, and `USER/GISTID` were never substituted.

## Root Cause

In `run()`, the `--files-only` check dispatches to `_run_files_only(args)` before any configure logic runs. The `_run_files_only` function never checked `args.configure_files`.

## Fix

After deploying template files in `_run_files_only`, if `--configure` is passed:
1. Read `.ghtraf.json` from the repo directory
2. Run `configure_dashboard`, `configure_readme`, and `configure_workflow`
3. All placeholders get substituted as expected

This makes the two-step workflow work:
```
ghtraf create --owner X --repo Y --configure --non-interactive  # cloud setup
ghtraf create --files-only --configure --non-interactive         # deploy + configure
```

## Scope note

This fixes Step 3 of the reproduction in #75 (the `--files-only --configure` no-op). #75 also covers Step 1 (first-run warnings when templates don't exist) and a suggested `ghtraf configure` subcommand. Those remain open in #75 after this merges.
